### PR TITLE
Elasticsearch: change install instructions (version 7.13.x)

### DIFF
--- a/code/elastictweet.py
+++ b/code/elastictweet.py
@@ -3,7 +3,7 @@
 # Example from:
 # https://elasticsearch-py.readthedocs.io/en/master/
 
-# pip3 install elasticsearch
+# pip install 'elasticsearch<7.14.0'
 
 # (If needed)
 # https://www.pg4e.com/code/hidden-dist.py

--- a/lectures/07-Elastic.txt
+++ b/lectures/07-Elastic.txt
@@ -1,5 +1,5 @@
 
 https://elasticsearch-py.readthedocs.io/en/master/
 
-pip install elasticsearch
+pip install 'elasticsearch<7.14.0'
 

--- a/tools/sql/07book.php
+++ b/tools/sql/07book.php
@@ -137,9 +137,18 @@ If necessary, copy <b>hidden-dist.py</b> to <b>hidden.py</b> and put your Elasti
 into the <b>elastic()</b> method.  You should also put your PostgreSQL secrets into this file as well.
 </p>
 <p>
-You will need to install the Python Elasticsearch library if you have not already done so.
+You will need to install the Python Elasticsearch library (version 7.13.x) if you have not already done so.
 <pre>
-pip install elasticsearch
+pip install 'elasticsearch<7.14.0'
+</pre>
+</p>
+<p>
+If installing elasticsearch locally run <b>pip</b> with the <b>-m</b> flag enabled:
+<pre>
+macOS: python3 -m pip install 'elasticsearch<7.14.0'
+</pre>
+<pre>
+Windows: python -m pip install 'elasticsearch<7.14.0'
 </pre>
 </p>
 <p>

--- a/tools/sql/07gmane.php
+++ b/tools/sql/07gmane.php
@@ -107,9 +107,18 @@ You should download these files:
 </ul>
 </p>
 <p>
-You will need to install the Python Elasticsearch library if you have not already done so.
+You will need to install the Python Elasticsearch library (version 7.13.x) if you have not already done so.
 <pre>
-pip install elasticsearch
+pip install 'elasticsearch<7.14.0'
+</pre>
+</p>
+<p>
+If installing elasticsearch locally run <b>pip</b> with the <b>-m</b> flag enabled:
+<pre>
+macOS: python3 -m pip install 'elasticsearch<7.14.0'
+</pre>
+<pre>
+Windows: python -m pip install 'elasticsearch<7.14.0'
 </pre>
 </p>
 <p>

--- a/tools/sql/07tweet.php
+++ b/tools/sql/07tweet.php
@@ -133,9 +133,18 @@ Then copy <b>hidden-dist.py</b> to <b>hidden.py</b> and put your Elasticsearch h
 into the <b>elastic()</b> method.  You should also put your PostgreSQL secrets into this file as well.
 </p>
 <p>
-You will need to install the Python Elasticsearch library:
+You will need to install the Python Elasticsearch library (version 7.13.x) if you have not already done so.
 <pre>
-pip install elasticsearch    # or pip3
+pip install 'elasticsearch<7.14.0'
+</pre>
+</p>
+<p>
+If installing elasticsearch locally run <b>pip</b> with the <b>-m</b> flag enabled:
+<pre>
+macOS: python3 -m pip install 'elasticsearch<7.14.0'
+</pre>
+<pre>
+Windows: python -m pip install 'elasticsearch<7.14.0'
 </pre>
 </p>
 <p>


### PR DESCRIPTION
SIADS 611 students are reporting errors when attempting to run the latest version of elasticsearch.

__Issue__
When running elasticbook.py, it returns the following error message:

> UnsupportedProductError: The client noticed that the server is not Elasticsearch and we do not support this unknown product

This indicates a compatibility issue with the most recent version of the Python elasticsearch package.

__Resolution__
Limit version to 7.13.x and update instructions.

`pip install elasticsearch`

to

`pip install 'elasticsearch<7.14.0'`

All references updated except instructions found in `pg4e_pyaw_es.md` (Python Anywhere). Unclear if this environment is also affected.