### PR TITLE
update assignment instructions, hide and prevent test edits

### DIFF
--- a/code/ipynb/03-normalization.ipynb
+++ b/code/ipynb/03-normalization.ipynb
@@ -7,7 +7,9 @@
     "Reading Normalized Data Quickly using a Database\n",
     "------------------------------------------------------------\n",
     "\n",
-    "In your readonly database, there is an un-normalized table called *home_value_by_zip* with 4,466,776 records of un-normalized data.  There is also a normalized copy of the same data in a few tables in the database.  Part of this assignment is about speed.  You must examine the tables using psql and figure out how to connect them and then construct an efficient SQL query in this notebook that will retrieve the requested data."
+    "In your readonly database, there is an un-normalized table called *home_value_by_zip* with 4,466,776 records of un-normalized data.  There is also a normalized copy of the same data in a few tables in the database.  This goal of this assignment is to use JOIN and GROUP BY to query the normalized data, resulting in faster and more efficient queries.\n",
+    "\n",
+    "You must examine the tables using psql and figure out how to connect them and then construct an efficient SQL query in this notebook that will retrieve the requested data."
    ]
   },
   {
@@ -29,11 +31,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sql_string = None\n",
-    "#sql_string = 'dbname=readonly user=readonly password=secret_xyzzy host=pg.pg4e.com port=5432'\n",
-    "    \n",
-    "if sql_string is None:\n",
-    "    raise Exception('You need to define your sql_string')\n"
+    "# Update this SQL connection string with correct readonly database credentials\n",
+    "sql_string = 'dbname=readonly user=readonly password=PLEASE_UPDATE_ME host=pg.pg4e.com port=5432'"
    ]
   },
   {
@@ -42,7 +41,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "conn = psycopg2.connect(sql_string,connect_timeout=3)"
+    "# open a new connection\n",
+    "# NOTE: this will raise an OperationalError if the readonly database credentials are not updated in the previous cell\n",
+    "conn = psycopg2.connect(sql_string,connect_timeout=3)\n",
+    "print(f\"connection created: {conn}\")"
    ]
   },
   {
@@ -80,23 +82,48 @@
    },
    "outputs": [],
    "source": [
-    "sql = None\n",
+    "state_avg_sql = None\n",
     "\n",
-    "### BEGIN SOLUTION\n",
-    "sql = '''SELECT state, avg(ym_val) AS average FROM home_value \n",
-    "... JOIN ...\n",
-    "ORDER BY average DESC LIMIT 10;'''\n",
+    "### DEFINE YOUR SQL QUERY HERE (NOTE: this query will fail as-is)\n",
+    "state_avg_sql = '''\n",
+    "SELECT\n",
+    "    state,\n",
+    "    avg(ym_val) AS average\n",
+    "FROM home_value \n",
+    "-- add JOIN and GROUP BY logic here...\n",
+    "ORDER BY average\n",
+    "DESC LIMIT 10;\n",
+    "'''\n",
     "### END SOLUTION\n",
     "\n",
-    "if sql is not None:\n",
-    "    df = pd.read_sql_query(sql, conn)\n",
-    "    df.head()"
+    "if state_avg_sql is None:\n",
+    "    raise Exception('Please define the sql query above')\n",
+    "\n",
+    "start_time = time.time()\n",
+    "state_avg_df = pd.read_sql_query(state_avg_sql, conn)\n",
+    "print(f\"state average execution time: {round(time.time()-start_time, 2)}s\")\n",
+    "state_avg_df.head()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "outputs": [],
+   "source": [
+    "### BEGIN HIDDEN TESTS\n",
+    "assert state_avg_df['state'][1] == 'HI'\n",
+    "assert state_avg_df['average'][1] > 384304\n",
+    "assert state_avg_df['average'][1] < 384305\n",
+    "assert state_avg_df['state'][3] == 'NJ'\n",
+    "assert state_avg_df['average'][3] > 313458\n",
+    "assert state_avg_df['average'][3] < 313459\n",
+    "\n",
+    "if state_avg_sql.lower().find('join') < 0 :\n",
+    "    raise Exception('You need to have a JOIN in your query')\n",
+    "### END HIDDEN TESTS"
+   ],
    "metadata": {
+    "editable": false,
     "nbgrader": {
      "grade": true,
      "grade_id": "cell-e94015b31a39e6d0",
@@ -104,34 +131,12 @@
      "points": 1,
      "schema_version": 3,
      "solution": false
+    },
+    "jupyter": {
+     "outputs_hidden": true,
+     "source_hidden": true
     }
-   },
-   "outputs": [],
-   "source": [
-    "if sql is None:\n",
-    "    raise Exception('You need to define the sql query')\n",
-    "    \n",
-    "assert df['state'][1] == 'HI'\n",
-    "assert df['average'][1] > 384304\n",
-    "assert df['average'][1] < 384305\n",
-    "\n",
-    "### BEGIN HIDDEN TESTS\n",
-    "if sql.lower().find('join') < 0 :\n",
-    "    raise Exception('You need to have a JOIN in your query')\n",
-    "\n",
-    "start = time.time()\n",
-    "df = pd.read_sql_query(sql, conn)\n",
-    "df.head()\n",
-    "delta = time.time() - start\n",
-    "print('Query execution time', delta)\n",
-    "if delta > 20.0 :\n",
-    "    raise Exception('Your query took too long')\n",
-    "\n",
-    "assert df['state'][3] == 'NJ'\n",
-    "assert df['average'][3] > 313458\n",
-    "assert df['average'][3] < 313459\n",
-    "### END HIDDEN TESTS"
-   ]
+   }
   },
   {
    "cell_type": "markdown",
@@ -168,24 +173,34 @@
    },
    "outputs": [],
    "source": [
-    "sql = None\n",
+    "city_avg_sql = None\n",
     "\n",
-    "### BEGIN SOLUTION\n",
-    "sql = '''SELECT city, avg(ym_val) AS average FROM home_value \n",
-    "... JOIN ...\n",
-    "ORDER BY average DESC LIMIT 10;'''\n",
-    "\n",
+    "### DEFINE YOUR SQL QUERY HERE (NOTE: this query will fail as-is)\n",
+    "city_avg_sql = '''\n",
+    "SELECT\n",
+    "    city,\n",
+    "    avg(ym_val) AS average\n",
+    "FROM home_value \n",
+    "-- add JOIN and GROUP BY logic here...\n",
+    "ORDER BY average\n",
+    "DESC LIMIT 10;\n",
+    "'''\n",
     "### END SOLUTION\n",
     "\n",
-    "if sql is not None:\n",
-    "    df = pd.read_sql_query(sql, conn)\n",
-    "    df.head()"
+    "if city_avg_sql is None:\n",
+    "    raise Exception('Please define the sql query above')\n",
+    "\n",
+    "start_time = time.time()\n",
+    "city_avg_df = pd.read_sql_query(city_avg_sql, conn)\n",
+    "print(f\"state average execution time: {round(time.time()-start_time, 2)}s\")\n",
+    "city_avg_df.head()\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "editable": false,
     "nbgrader": {
      "grade": true,
      "grade_id": "cell-dbf5ff3e57889dc7",
@@ -193,43 +208,26 @@
      "points": 1,
      "schema_version": 3,
      "solution": false
+    },
+    "jupyter": {
+     "outputs_hidden": true,
+     "source_hidden": true
     }
    },
    "outputs": [],
    "source": [
-    "if sql is None:\n",
-    "    raise Exception('You need to define the sql query')\n",
-    "\n",
-    "assert df['city'][1] == 'Portola Valley'\n",
-    "assert df['average'][1] > 2218466\n",
-    "assert df['average'][1] < 2218467\n",
-    "\n",
     "### BEGIN HIDDEN TESTS\n",
-    "if sql.lower().find('join') < 0 :\n",
+    "assert city_avg_df['city'][1] == 'Portola Valley'\n",
+    "assert city_avg_df['average'][1] > 2218466\n",
+    "assert city_avg_df['average'][1] < 2218467\n",
+    "assert city_avg_df['city'][3] == 'Montecito'\n",
+    "assert city_avg_df['average'][3] > 1939405\n",
+    "assert city_avg_df['average'][3] < 1939406\n",
+    "\n",
+    "if city_avg_sql.lower().find('join') < 0 :\n",
     "    raise Exception('You need to have a JOIN in your query')\n",
-    "\n",
-    "start = time.time()\n",
-    "my_df = pd.read_sql_query(sql, conn)\n",
-    "my_df.head()\n",
-    "delta = time.time() - start\n",
-    "print('Query execution time', delta)\n",
-    "if delta > 20.0 :\n",
-    "    raise Exception('Your query took too long')\n",
-    "my_df.head()\n",
-    "\n",
-    "assert my_df['city'][3] == 'Montecito'\n",
-    "assert my_df['average'][3] > 1939405\n",
-    "assert my_df['average'][3] < 1939406\n",
-    "\n",
     "### END HIDDEN TESTS"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR slightly reworks the week 4 normalization assignment:
  * ensures the two queries are only run once (both for debugging and validation tests)
  * tests are hidden by default, and if expanded, cannot be edited

It is still possible to edit the notebook JSON directly, but hopefully will reduce intermittent timeouts even when valid queries, and will hide tests by default.