### PR TITLE
07deno-book.php - show correct https://deno.pg4e.com URL in shared-server assignment

### DIFF
--- a/tools/deno/07deno-book.php
+++ b/tools/deno/07deno-book.php
@@ -29,6 +29,9 @@ $oldgrade = $RESULT->grade;
 $url = isset($_REQUEST['url']) ? $_REQUEST['url'] : "";
 $url = rtrim(trim($url), '/');
 $sampleurl = "https://comfortable-starling-12.deno.dev";
+if ( $shared_server ) {
+    $sampleurl = "https://deno.pg4e.com";
+}
 if ( strlen($url) > 0 ) $sampleurl = $url;
 
 if ( $dueDate->message ) {


### PR DESCRIPTION
In the shared server implementation of the DenoKV Book Data Model autograder (when `$shared_server` is true in `07deno-book.php`), the page displays the demo URL `https://comfortable-starling-12.deno.dev` inside the hidden.py excerpt, even though the instructions and the autograder logic refer to the shared DenoKV instance at `https://deno.pg4e.com`. Please see [Autograder: DenoKV Book Data Model (shared server - no install required)](https://www.pg4e.com/tools/deno/?PHPSESSID=62310eaf34edea53ee1e29278f222cf5).

Fix
---
* Set `$sampleurl = 'https://deno.pg4e.com'` when `$shared_server` is true.

This mirrors the behaviour already implemented in
`tools/deno/07deno-text.php`, and keeps the two graders consistent. No changes were made to the grading steps themselves (please note that this fix was tested using MAMP and mocking the various dependencies in `07deno-book.php`, since this was simpler than running PG4E/Tsugi locally).